### PR TITLE
removing autowired for field injection

### DIFF
--- a/src/main/java/com/fiap/parkmongoapi/controller/MotoristaController.java
+++ b/src/main/java/com/fiap/parkmongoapi/controller/MotoristaController.java
@@ -9,10 +9,17 @@ import com.fiap.parkmongoapi.validations.ValidCpf;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
@@ -20,12 +27,12 @@ import java.util.ArrayList;
 
 @RestController
 @RequestMapping(value = "/motorista")
+@RequiredArgsConstructor
 @Validated
 @Tag(name = "Motorista", description = "API para gerenciar motoristas")
 public class MotoristaController {
 
-    @Autowired
-    private MotoristaService motoristaService;
+    private final MotoristaService motoristaService;
 
     @GetMapping("/{cpf}")
     @Operation(summary = "Consultar Motorista por CPF",

--- a/src/main/java/com/fiap/parkmongoapi/controller/TicketController.java
+++ b/src/main/java/com/fiap/parkmongoapi/controller/TicketController.java
@@ -1,24 +1,33 @@
 package com.fiap.parkmongoapi.controller;
 
-import com.fiap.parkmongoapi.dto.ticket.*;
+import com.fiap.parkmongoapi.dto.ticket.CadastroTicketDTO;
+import com.fiap.parkmongoapi.dto.ticket.TicketCancelledDTO;
+import com.fiap.parkmongoapi.dto.ticket.TicketCreatedDTO;
+import com.fiap.parkmongoapi.dto.ticket.TicketPaidDTO;
+import com.fiap.parkmongoapi.dto.ticket.TicketViewDTO;
 import com.fiap.parkmongoapi.service.TicketService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
 
 @RestController
 @RequestMapping(value = "/ticket")
+@RequiredArgsConstructor
 @Tag(name = "Ticket", description = "API para gerenciar park tickets")
 public class TicketController {
 
-    @Autowired
-    private TicketService ticketService;
+    private final TicketService ticketService;
 
     @PostMapping
     @Operation(summary = "Cadastrar um novo ticket",

--- a/src/main/java/com/fiap/parkmongoapi/controller/VagaController.java
+++ b/src/main/java/com/fiap/parkmongoapi/controller/VagaController.java
@@ -12,21 +12,27 @@ import com.fiap.parkmongoapi.service.VagaService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping(value = "/vaga")
+@RequiredArgsConstructor
 @Tag(name = "Vaga", description = "API para gerenciar vagas")
 public class VagaController {
 
-    @Autowired
-    private VagaService vagaService;
+    private final VagaService vagaService;
 
     @PostMapping
     @Operation(summary = "Criar uma nova vaga",

--- a/src/main/java/com/fiap/parkmongoapi/controller/VeiculoController.java
+++ b/src/main/java/com/fiap/parkmongoapi/controller/VeiculoController.java
@@ -11,12 +11,19 @@ import com.fiap.parkmongoapi.validations.ValidCpf;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Pattern;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
@@ -24,11 +31,11 @@ import java.net.URI;
 
 @RestController
 @RequestMapping(value = "/veiculo")
+@RequiredArgsConstructor
 @Tag(name = "Veiculo", description = "API para gerenciar veiculos")
 public class VeiculoController {
 
-    @Autowired
-    private VeiculoService veiculoService;
+    private final VeiculoService veiculoService;
 
     @PostMapping("/{cpfMotorista}")
     @Operation(summary = "Cadastrar Veiculos de Motorista", description = "Cadastra um novo veiculo vinculado a um cpf.")

--- a/src/main/java/com/fiap/parkmongoapi/service/impl/MotoristaServiceImpl.java
+++ b/src/main/java/com/fiap/parkmongoapi/service/impl/MotoristaServiceImpl.java
@@ -5,16 +5,16 @@ import com.fiap.parkmongoapi.exception.motorista.MotoristaNotFoundException;
 import com.fiap.parkmongoapi.model.Motorista;
 import com.fiap.parkmongoapi.repository.MotoristaRepository;
 import com.fiap.parkmongoapi.service.MotoristaService;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 
 @Service
+@RequiredArgsConstructor
 public class MotoristaServiceImpl implements MotoristaService {
 
-    @Autowired
-    private MotoristaRepository motoristaRepository;
+    private final MotoristaRepository motoristaRepository;
 
     @Override
     public Motorista consultarMotoristaPorCpf(String cpf) {

--- a/src/main/java/com/fiap/parkmongoapi/service/impl/TicketServiceImpl.java
+++ b/src/main/java/com/fiap/parkmongoapi/service/impl/TicketServiceImpl.java
@@ -1,6 +1,10 @@
 package com.fiap.parkmongoapi.service.impl;
 
-import com.fiap.parkmongoapi.dto.ticket.*;
+import com.fiap.parkmongoapi.dto.ticket.CadastroTicketDTO;
+import com.fiap.parkmongoapi.dto.ticket.TicketCancelledDTO;
+import com.fiap.parkmongoapi.dto.ticket.TicketCreatedDTO;
+import com.fiap.parkmongoapi.dto.ticket.TicketPaidDTO;
+import com.fiap.parkmongoapi.dto.ticket.TicketViewDTO;
 import com.fiap.parkmongoapi.exception.motorista.MotoristaNotFoundException;
 import com.fiap.parkmongoapi.exception.ticket.TicketAlreadyCancelledException;
 import com.fiap.parkmongoapi.exception.ticket.TicketAlreadyPaidException;
@@ -18,7 +22,7 @@ import com.fiap.parkmongoapi.service.TicketService;
 import com.fiap.parkmongoapi.utils.TicketUtils;
 import com.fiap.parkmongoapi.utils.VagaUtils;
 import com.fiap.parkmongoapi.utils.VeiculoUtils;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -28,19 +32,13 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 @Service
+@RequiredArgsConstructor
 public class TicketServiceImpl implements TicketService {
 
-    @Autowired
-    private TicketRepository ticketRepository;
-
-    @Autowired
-    private VagaRepository vagaRepository;
-
-    @Autowired
-    private MotoristaRepository motoristaRepository;
-
-    @Autowired
-    private VeiculoRepository veiculoRepository;
+    private final TicketRepository ticketRepository;
+    private final VagaRepository vagaRepository;
+    private final MotoristaRepository motoristaRepository;
+    private final VeiculoRepository veiculoRepository;
 
     public TicketCreatedDTO cadastrarTicket(CadastroTicketDTO cadastroTicketDTO) {
 

--- a/src/main/java/com/fiap/parkmongoapi/service/impl/VagaServiceImpl.java
+++ b/src/main/java/com/fiap/parkmongoapi/service/impl/VagaServiceImpl.java
@@ -5,13 +5,12 @@ import com.fiap.parkmongoapi.dto.vaga.AtualizaVagaDTO;
 import com.fiap.parkmongoapi.dto.vaga.CadastroVagaDTO;
 import com.fiap.parkmongoapi.dto.vaga.VagaFiltroDTO;
 import com.fiap.parkmongoapi.dto.vaga.VagaResponseDTO;
-
 import com.fiap.parkmongoapi.model.Endereco;
 import com.fiap.parkmongoapi.model.Vaga;
 import com.fiap.parkmongoapi.repository.VagaRepository;
 import com.fiap.parkmongoapi.service.VagaService;
 import com.fiap.parkmongoapi.utils.VagaUtils;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
@@ -21,16 +20,12 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class VagaServiceImpl implements VagaService {
 
-    @Autowired
-    private VagaRepository vagaRepository;
-
-    @Autowired
-    private MongoTemplate mongoTemplate;
-
-    @Autowired
-    private VagaUtils vagaUtils;
+    private final VagaRepository vagaRepository;
+    private final MongoTemplate mongoTemplate;
+    private final VagaUtils vagaUtils;
 
     @Override
     public Vaga criarVaga(CadastroVagaDTO vaga) {

--- a/src/main/java/com/fiap/parkmongoapi/service/impl/VeiculoServiceImpl.java
+++ b/src/main/java/com/fiap/parkmongoapi/service/impl/VeiculoServiceImpl.java
@@ -12,7 +12,7 @@ import com.fiap.parkmongoapi.model.Veiculo;
 import com.fiap.parkmongoapi.repository.MotoristaRepository;
 import com.fiap.parkmongoapi.repository.VeiculoRepository;
 import com.fiap.parkmongoapi.service.VeiculoService;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -21,13 +21,11 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class VeiculoServiceImpl implements VeiculoService {
 
-    @Autowired
-    private MotoristaRepository motoristaRepository;
-
-    @Autowired
-    private VeiculoRepository veiculoRepository;
+    private final MotoristaRepository motoristaRepository;
+    private final VeiculoRepository veiculoRepository;
 
 
     @Override

--- a/src/main/java/com/fiap/parkmongoapi/utils/VagaUtils.java
+++ b/src/main/java/com/fiap/parkmongoapi/utils/VagaUtils.java
@@ -6,16 +6,16 @@ import com.fiap.parkmongoapi.model.Vaga;
 import com.fiap.parkmongoapi.model.counter.EnderecoCounter;
 import com.fiap.parkmongoapi.repository.VagaRepository;
 import com.fiap.parkmongoapi.repository.counterRepository.EnderecoCounterRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
 
 @Component
+@RequiredArgsConstructor
 public class VagaUtils {
 
-    @Autowired
-    private EnderecoCounterRepository enderecoCounterRepository;
+    private final EnderecoCounterRepository enderecoCounterRepository;
 
     public String gerarIdCustomizado(Endereco endereco) {
         // Gera o hash do endereço


### PR DESCRIPTION
Não é recomendado usar @Autowired na injeção de dependencia, substitui pela injeção de Construtor usando o @RequiredArgsConstructor e private final nas variaveis.

https://www.baeldung.com/java-spring-field-injection-cons